### PR TITLE
Cache expiry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ coverage-html:
 	JOURNEYS_BASE_URL=http://localhost:5678 JOURNEYS_VA_BASE_URL="https://data.itsfactory.fi/journeys/api/1" go test -count=1 -tags=all_tests -coverprofile cover.out ./... && go tool cover -html=cover.out -o coverage.html
 tre:
 	MEMCACHED_URL="localhost:11211" JOURNEYS_GTFS_PATH=.gtfs JOURNEYS_BASE_URL="https://data.itsfactory.fi/journeys/api/1" JOURNEYS_VA_BASE_URL="https://data.itsfactory.fi/journeys/api/1" go run cmd/journeys/journeys.go start
+tre-custom-cache:
+	MEMCACHED_URL="localhost:11211" JOURNEYS_GTFS_PATH=.gtfs JOURNEYS_BASE_URL="https://data.itsfactory.fi/journeys/api/1" JOURNEYS_VA_BASE_URL="https://data.itsfactory.fi/journeys/api/1" JOURNEYS_SHORT_CACHE_LOWER_BOUND="0" JOURNEYS_SHORT_CACHE_UPPER_BOUND="5" JOURNEYS_SHORT_CACHE_DURATION="10s" JOURNEYS_LONG_CACHE_DURATION="30s" go run cmd/journeys/journeys.go start
 tre-no-cache:
 	MEMCACHED_URL="localhost:11211" JOURNEYS_GTFS_PATH=.gtfs JOURNEYS_BASE_URL="https://data.itsfactory.fi/journeys/api/1" JOURNEYS_VA_BASE_URL="https://data.itsfactory.fi/journeys/api/1" go run cmd/journeys/journeys.go start --disable-cache
 tre-dry:

--- a/internal/app/journeys/handlers/v1/journeys.go
+++ b/internal/app/journeys/handlers/v1/journeys.go
@@ -66,7 +66,7 @@ func convertJourney(j *model.Journey, baseUrl string, vehicleActivityBaseUrl str
 
 	return Journey{
 		Url:                  fmt.Sprintf("%v%v/%v", baseUrl, journeysPrefix, j.Id),
-		ActivityUrl:          fmt.Sprintf("%v%v/%v", vehicleActivityBaseUrl, "/vehicle-activity", j.ActivityId),
+		ActivityUrl:          fmt.Sprintf("%v%v?journeyRef=%v", vehicleActivityBaseUrl, "/vehicle-activity", j.ActivityId),
 		HeadSign:             j.HeadSign,
 		Direction:            j.Direction,
 		WheelchairAccessible: j.WheelchairAccessible,

--- a/internal/app/journeys/server/memcached.go
+++ b/internal/app/journeys/server/memcached.go
@@ -6,17 +6,36 @@ import (
 	"github.com/bradfitz/gomemcache/memcache"
 	"net/http"
 	"os"
+	"time"
 )
 
-func NewMemcachedCacheMiddleware(client *memcache.Client) (*MemcachedCacheMiddleware, error) {
+func NewMemcachedCacheMiddleware(client *memcache.Client, shortCacheDuration time.Duration, longCacheDuration time.Duration, shortCachePeriodLowerBound int, shortCachePeriodUpperBound int) (*MemcachedCacheMiddleware, error) {
 	if os.Getenv("MEMCACHED_URL") == "" {
 		return nil, errors.New("MEMCACHED_URL not set in environment, but memcached is configured. Cannot proceed")
 	}
-	return &MemcachedCacheMiddleware{client: client}, nil
+	return &MemcachedCacheMiddleware{
+		client:                     client,
+		shortCacheDuration:         shortCacheDuration,
+		longCacheDuration:          longCacheDuration,
+		shortCachePeriodLowerBound: shortCachePeriodLowerBound,
+		shortCachePeriodUpperBound: shortCachePeriodUpperBound,
+	}, nil
 }
 
 type MemcachedCacheMiddleware struct {
-	client *memcache.Client
+	client                     *memcache.Client
+	shortCacheDuration         time.Duration
+	longCacheDuration          time.Duration
+	shortCachePeriodLowerBound int
+	shortCachePeriodUpperBound int
+}
+
+func (mcm *MemcachedCacheMiddleware) Flush() error {
+	err := mcm.client.DeleteAll()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (mcm *MemcachedCacheMiddleware) Middleware(next http.Handler) http.Handler {
@@ -37,8 +56,23 @@ func (mcm *MemcachedCacheMiddleware) Middleware(next http.Handler) http.Handler 
 		rw := NewResponseWriter(w)
 		next.ServeHTTP(rw, r)
 
+		// Determine expiration based on time of day
+		// Night hours (e.g., 00:00 - 05:00) have a shorter cache duration
+		// This is because the "service day" ends at night after the last service has completed. There is often
+		// a gap between the last service and the first service of the next day, which allows the cache to clear before
+		// the next day's services begin if the cache period is short.
+		var expiration int32
+		now := time.Now()
+		hour := now.Hour()
+
+		if hour >= mcm.shortCachePeriodLowerBound && hour <= mcm.shortCachePeriodUpperBound { // Night hours (e.g., 00:00 - 05:00)
+			expiration = int32(time.Now().Add(mcm.shortCacheDuration).Unix())
+		} else {
+			expiration = int32(time.Now().Add(mcm.longCacheDuration).Unix())
+		}
+
 		// Cache the new response
-		_ = mcm.client.Set(&memcache.Item{Key: key, Value: rw.forCache.Bytes()})
+		_ = mcm.client.Set(&memcache.Item{Key: key, Value: rw.forCache.Bytes(), Expiration: expiration})
 	})
 }
 


### PR DESCRIPTION
This commit implements cache controls which allow the cached items to expire according to configured rules. Two cache modes are supported: short and long. The short cache can be used for example during night when the service day is about to expire, and the cache must invalidate during the period between last journey of the previous service day and the start of the next service day.